### PR TITLE
Develop okamoto

### DIFF
--- a/blackjack_rl/script/lspi_learn.py
+++ b/blackjack_rl/script/lspi_learn.py
@@ -1,6 +1,7 @@
 from blackjack_rl.envs.eleven_ace import BlackjackEnv
 from blackjack_rl.agent.lspi import LSPIAgent
 import os,pickle
+import datetime
 
 # environment seed
 seed = 5
@@ -48,5 +49,8 @@ if __name__ == '__main__':
     # save result
     print(rewards)
     os.makedirs(data_dir, exist_ok=True)
-    with open(os.path.join(data_dir, "lspi_rewards.txt"), "wb") as f:
+    now = datetime.datetime.now()
+    with open(os.path.join(data_dir, "lspi_rewards.pkl"), "wb") as f:
+        pickle.dump(rewards, f)
+    with open(os.path.join(data_dir, "lspi_rewards_"+now.strftime('%Y%m%d_%H%M%S')+".pkl"), "wb") as f:
         pickle.dump(rewards, f)

--- a/blackjack_rl/script/lspi_learn.py
+++ b/blackjack_rl/script/lspi_learn.py
@@ -6,14 +6,11 @@ import datetime
 # environment seed
 seed = 5
 # make_sample episode count
-#N_epoch = 100
-N_epoch = 10
+N_epoch = 100
 # LSPI train count
-#N_episode = 10000
-N_episode = 100
+N_episode = 10000
 # Evaluation count per leaning
-#N_eval = 10000
-N_eval = 100
+N_eval = 10000
 # data dir
 _base = os.path.dirname(os.path.abspath(__file__))#実行中のファイル(このファイル)の絶対パス
 data_dir = os.path.join(_base, "../../data")#実行中のファイルからの相対パスでdataの出力先を決定

--- a/blackjack_rl/script/lspi_learn.py
+++ b/blackjack_rl/script/lspi_learn.py
@@ -14,6 +14,7 @@ N_eval = 10000
 # data dir
 _base = os.path.dirname(os.path.abspath(__file__))#実行中のファイル(このファイル)の絶対パス
 data_dir = os.path.join(_base, "../../data")#実行中のファイルからの相対パスでdataの出力先を決定
+detail_dir = os.path.join(_base, "../../data/detail")
 
 
 if __name__ == '__main__':
@@ -46,8 +47,9 @@ if __name__ == '__main__':
     # save result
     print(rewards)
     os.makedirs(data_dir, exist_ok=True)
+    os.makedirs(detail_dir, exist_ok=True)
     now = datetime.datetime.now()
     with open(os.path.join(data_dir, "lspi_rewards.pkl"), "wb") as f:
         pickle.dump(rewards, f)
-    with open(os.path.join(data_dir, "lspi_rewards_"+now.strftime('%Y%m%d_%H%M%S')+".pkl"), "wb") as f:
+    with open(os.path.join(detail_dir, "lspi_rewards_"+now.strftime('%Y%m%d_%H%M%S')+".pkl"), "wb") as f:
         pickle.dump(rewards, f)

--- a/blackjack_rl/script/lspi_learn.py
+++ b/blackjack_rl/script/lspi_learn.py
@@ -5,13 +5,17 @@ import os,pickle
 # environment seed
 seed = 5
 # make_sample episode count
-N_epoch = 100
+#N_epoch = 100
+N_epoch = 10
 # LSPI train count
-N_episode = 10000
+#N_episode = 10000
+N_episode = 100
 # Evaluation count per leaning
-N_eval = 10000
+#N_eval = 10000
+N_eval = 100
 # data dir
-data_dir = "../../data"
+_base = os.path.dirname(os.path.abspath(__file__))#実行中のファイル(このファイル)の絶対パス
+data_dir = os.path.join(_base, "../../data")#実行中のファイルからの相対パスでdataの出力先を決定
 
 
 if __name__ == '__main__':

--- a/blackjack_rl/script/monte_learn.py
+++ b/blackjack_rl/script/monte_learn.py
@@ -1,6 +1,7 @@
 from blackjack_rl.envs.eleven_ace import BlackjackEnv
 from blackjack_rl.agent.qtable import QTableAgent
 import os, pickle
+import datetime
 
 # environment seed
 seed = 3
@@ -11,7 +12,8 @@ N_episode = 10000
 # Evaluation count per leaning
 N_eval = 10000
 # data dir
-data_dir = "../../data"
+_base = os.path.dirname(os.path.abspath(__file__))#実行中のファイル(このファイル)の絶対パス
+data_dir = os.path.join(_base, "../../data")#実行中のファイルからの相対パスでdataの出力先を決定
 
 if __name__ == '__main__':
     # initialize
@@ -38,5 +40,8 @@ if __name__ == '__main__':
 
     # save result
     os.makedirs(data_dir, exist_ok=True)
-    with open(os.path.join(data_dir, "monte_rewards.txt"), "wb") as f:
+    now = datetime.datetime.now()
+    with open(os.path.join(data_dir, "monte_rewards.pkl"), "wb") as f:
+        pickle.dump(rewards, f)
+    with open(os.path.join(data_dir, "monte_rewards_"+now.strftime('%Y%m%d_%H%M%S')+".pkl"), "wb") as f:
         pickle.dump(rewards, f)

--- a/blackjack_rl/script/monte_learn.py
+++ b/blackjack_rl/script/monte_learn.py
@@ -14,6 +14,7 @@ N_eval = 10000
 # data dir
 _base = os.path.dirname(os.path.abspath(__file__))#実行中のファイル(このファイル)の絶対パス
 data_dir = os.path.join(_base, "../../data")#実行中のファイルからの相対パスでdataの出力先を決定
+detail_dir = os.path.join(_base, "../../data/detail")
 
 if __name__ == '__main__':
     # initialize
@@ -40,8 +41,9 @@ if __name__ == '__main__':
 
     # save result
     os.makedirs(data_dir, exist_ok=True)
+    os.makedirs(detail_dir, exist_ok=True)
     now = datetime.datetime.now()
     with open(os.path.join(data_dir, "monte_rewards.pkl"), "wb") as f:
         pickle.dump(rewards, f)
-    with open(os.path.join(data_dir, "monte_rewards_"+now.strftime('%Y%m%d_%H%M%S')+".pkl"), "wb") as f:
+    with open(os.path.join(detail_dir, "monte_rewards_"+now.strftime('%Y%m%d_%H%M%S')+".pkl"), "wb") as f:
         pickle.dump(rewards, f)

--- a/blackjack_rl/script/plot_performance.py
+++ b/blackjack_rl/script/plot_performance.py
@@ -14,11 +14,11 @@ def plot_performance():
     paths = [lspi_path, monte_path, qlearning_path]
     names = ["lspi", "monte", "qlearning"]
     fig = plt.figure()
-    x = list(range(100))
     for idx, path in enumerate(paths):
         if os.path.exists(path):
             with open(path, "rb") as f:
                 data = pickle.load(f)
+                x = list(range(len(data)))
                 print(data)
                 ax = fig.add_subplot(1, 1, 1)
                 ax.plot(x, data, label=names[idx])

--- a/blackjack_rl/script/plot_performance.py
+++ b/blackjack_rl/script/plot_performance.py
@@ -5,8 +5,8 @@ import os, pickle
 _base = os.path.dirname(os.path.abspath(__file__))#実行中のファイル(このファイル)の絶対パス
 data_dir = os.path.join(_base, "../../data")#実行中のファイルからの相対パスでdataの出力先を決定
 lspi_path = os.path.join(data_dir, "lspi_rewards.pkl")
-monte_path = os.path.join(data_dir, "monte_rewards.txt")
-qlearning_path = os.path.join(data_dir, "qlearning_rewards.txt")
+monte_path = os.path.join(data_dir, "monte_rewards.pkl")
+qlearning_path = os.path.join(data_dir, "qlearning_rewards.pkl")
 plot_path = os.path.join(data_dir, "performance.jpg")
 
 

--- a/blackjack_rl/script/plot_performance.py
+++ b/blackjack_rl/script/plot_performance.py
@@ -2,7 +2,8 @@ from matplotlib import pyplot as plt
 import os, pickle
 
 # data dir
-data_dir = "../../data"
+_base = os.path.dirname(os.path.abspath(__file__))#実行中のファイル(このファイル)の絶対パス
+data_dir = os.path.join(_base, "../../data")#実行中のファイルからの相対パスでdataの出力先を決定
 lspi_path = os.path.join(data_dir, "lspi_rewards.txt")
 monte_path = os.path.join(data_dir, "monte_rewards.txt")
 qlearning_path = os.path.join(data_dir, "qlearning_rewards.txt")

--- a/blackjack_rl/script/plot_performance.py
+++ b/blackjack_rl/script/plot_performance.py
@@ -4,7 +4,7 @@ import os, pickle
 # data dir
 _base = os.path.dirname(os.path.abspath(__file__))#実行中のファイル(このファイル)の絶対パス
 data_dir = os.path.join(_base, "../../data")#実行中のファイルからの相対パスでdataの出力先を決定
-lspi_path = os.path.join(data_dir, "lspi_rewards.txt")
+lspi_path = os.path.join(data_dir, "lspi_rewards.pkl")
 monte_path = os.path.join(data_dir, "monte_rewards.txt")
 qlearning_path = os.path.join(data_dir, "qlearning_rewards.txt")
 plot_path = os.path.join(data_dir, "performance.jpg")

--- a/blackjack_rl/script/qlearning_learn.py
+++ b/blackjack_rl/script/qlearning_learn.py
@@ -1,6 +1,7 @@
 from blackjack_rl.envs.eleven_ace import BlackjackEnv
 from blackjack_rl.agent.qtable import QTableAgent
 import os, pickle
+import datetime
 
 # environment seed
 seed = 3
@@ -11,7 +12,8 @@ N_episode = 10000
 # Evaluation count per leaning
 N_eval = 10000
 # data dir
-data_dir = "../../data"
+_base = os.path.dirname(os.path.abspath(__file__))#実行中のファイル(このファイル)の絶対パス
+data_dir = os.path.join(_base, "../../data")#実行中のファイルからの相対パスでdataの出力先を決定
 
 if __name__ == '__main__':
     # initialize
@@ -38,5 +40,8 @@ if __name__ == '__main__':
 
     # save result
     os.makedirs(data_dir, exist_ok=True)
-    with open(os.path.join(data_dir, "qlearning_rewards.txt"), "wb") as f:
+    now = datetime.datetime.now()
+    with open(os.path.join(data_dir, "qlearning_rewards.pkl"), "wb") as f:
+        pickle.dump(rewards, f)
+    with open(os.path.join(data_dir, "qlearning_rewards_"+now.strftime('%Y%m%d_%H%M%S')+".pkl"), "wb") as f:
         pickle.dump(rewards, f)

--- a/blackjack_rl/script/qlearning_learn.py
+++ b/blackjack_rl/script/qlearning_learn.py
@@ -14,6 +14,7 @@ N_eval = 10000
 # data dir
 _base = os.path.dirname(os.path.abspath(__file__))#実行中のファイル(このファイル)の絶対パス
 data_dir = os.path.join(_base, "../../data")#実行中のファイルからの相対パスでdataの出力先を決定
+detail_dir = os.path.join(_base, "../../data/detail")
 
 if __name__ == '__main__':
     # initialize
@@ -40,8 +41,9 @@ if __name__ == '__main__':
 
     # save result
     os.makedirs(data_dir, exist_ok=True)
+    os.makedirs(detail_dir, exist_ok=True)
     now = datetime.datetime.now()
     with open(os.path.join(data_dir, "qlearning_rewards.pkl"), "wb") as f:
         pickle.dump(rewards, f)
-    with open(os.path.join(data_dir, "qlearning_rewards_"+now.strftime('%Y%m%d_%H%M%S')+".pkl"), "wb") as f:
+    with open(os.path.join(detail_dir, "qlearning_rewards_"+now.strftime('%Y%m%d_%H%M%S')+".pkl"), "wb") as f:
         pickle.dump(rewards, f)


### PR DESCRIPTION
相対パスの起点を実行ファイルの位置に指定
日付付きのファイルも出力するようにした
拡張子をpklに変更
グラフの横軸が100エポックで固定な問題を修正
